### PR TITLE
Quickfix for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     },
     "dependencies": {
         "fs-extra-promise": "1.0.1",
-        "@types/fs-extra-promise": "1.0.0"
+        "@types/fs-extra-promise": "1.0.1"
     },
     "devDependencies": {
         "typescript": "^2.0.3",

--- a/src/index/referenceindex.ts
+++ b/src/index/referenceindex.ts
@@ -4,6 +4,10 @@ export interface Reference {
     path:string;
 }
 
+export function isPathToAnotherDir(path: string) {
+    return path.startsWith('../') || path.startsWith('..\\');
+}
+
 export class ReferenceIndex {
     private referencedBy:{[key:string]:Reference[]} = {}; //path -> all of the files that reference it
 
@@ -57,10 +61,10 @@ export class ReferenceIndex {
         let added:{[key:string]:boolean} = {};
 
         for(let p in this.referencedBy) {
-            if(!path.relative(directory, p).startsWith('../')) {
+            if(!isPathToAnotherDir(path.relative(directory, p))) {
                 this.referencedBy[p].forEach(reference => {
                     if(added[reference.path]) return;
-                    if(path.relative(directory, reference.path).startsWith('../')) {
+                    if(isPathToAnotherDir(path.relative(directory, reference.path))) {
                         result.push(reference);
                         added[reference.path] = true;
                     }

--- a/src/index/referenceindexer.ts
+++ b/src/index/referenceindexer.ts
@@ -1,4 +1,4 @@
-import {ReferenceIndex} from './referenceindex';
+import { ReferenceIndex, isPathToAnotherDir } from './referenceindex';
 import * as fs from 'fs-extra-promise';
 import * as vscode from 'vscode';
 import * as path from 'path';
@@ -14,7 +14,8 @@ interface Edit {
 }
 
 export function isInDir(dir:string, p:string) {
-    return !path.relative(dir, p).startsWith('../');
+    let relative = path.relative(dir, p);
+    return !isPathToAnotherDir(relative);
 }
 
 
@@ -241,7 +242,7 @@ export class ReferenceIndexer {
                     let references = this.getRelativeReferences(text);
                     let change = references.filter(p => {
                         let abs = this.resolveRelativeReference(originalPath, p);
-                        return path.relative(from, abs).startsWith('../');
+                        return isPathToAnotherDir(path.relative(from, abs));
                     }).map((p):Replacement => {
                         let abs = this.resolveRelativeReference(originalPath, p);
                         let relative = this.getRelativePath(file.fsPath, abs);
@@ -262,7 +263,7 @@ export class ReferenceIndexer {
                 let imports = this.getRelativeReferences(text);
                 let change = imports.filter(p => {
                     let abs = this.resolveRelativeReference(reference.path, p);
-                    return !path.relative(from, abs).startsWith('../')
+                    return !isPathToAnotherDir(path.relative(from, abs));
                 }).map((p):[string,string] => {
                     let abs = this.resolveRelativeReference(reference.path, p);
                     let relative = path.relative(from, abs);
@@ -352,6 +353,7 @@ export class ReferenceIndexer {
             }
         }
         let relative = path.relative(path.dirname(from), to);
+        relative = relative.replace(/\\/g, "/");
         if(!relative.startsWith('.')) {
             relative = './' + relative;
         }


### PR DESCRIPTION
Made fixes for the plugin to work in Windows. The problem was that "path" returns the paths in the operating system format, and typescript expects them in unix format.