### PR TITLE
Add option to remove index filename from updated imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Moves TypeScript files and folders containing TypeScript and updates their relat
 
 ## Release Notes
 
+## 1.12.0
+
+Added the ability to remove the filename from index file imports. To enable set `movets.removeIndexSuffix` to `true` in User Settings.
+
 ## 1.11.3
 
 Add support for path mapping for Windows users.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Moves TypeScript files and folders containing TypeScript and updates their relat
 
 ## 1.12.0
 
-Added the ability to remove the filename from index file imports. To enable set `movets.removeIndexSuffix` to `true` in User Settings.
+Added the ability to remove the filename from index file imports. To disable set `movets.removeIndexSuffix` to `false` in User Settings.
 
 ## 1.11.3
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
                 },
                 "movets.removeIndexSuffix": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Removes index filename from imports"
                 }
             }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "move-ts",
     "displayName": "Move TS - Move TypeScript files and update relative imports",
     "description": "extension for moving typescript files and folders and updating relative imports in your workspace",
-    "version": "1.11.5",
+    "version": "1.12.0",
     "publisher": "stringham",
     "repository": {
         "type": "git",
@@ -74,6 +74,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Make edits in vscode instead of saving the changes to disk."
+                },
+                "movets.removeIndexSuffix": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Removes index filename from imports"
                 }
             }
         }
@@ -85,16 +90,16 @@
         "test": "node ./node_modules/vscode/bin/test"
     },
     "dependencies": {
-        "typescript": "^2.7.1",
+        "typescript": "^3.7.5",
         "fs-extra-promise": "1.0.1",
-        "@types/fs-extra-promise": "1.0.1",
+        "@types/fs-extra-promise": "1.0.8",
         "minimatch": "3.0.4"
     },
     "devDependencies": {
-        "vscode": "^1.1.10",
-        "mocha": "^2.3.3",
-        "@types/node": "^6.0.40",
-        "@types/minimatch": "2.0.29",
-        "@types/mocha": "^2.2.32"
+        "vscode": "^1.1.36",
+        "mocha": "^7.0.1",
+        "@types/node": "13.7.0",
+        "@types/minimatch": "3.0.3",
+        "@types/mocha": "^7.0.1"
     }
 }

--- a/src/index/referenceindexer.ts
+++ b/src/index/referenceindexer.ts
@@ -416,7 +416,7 @@ export class ReferenceIndexer {
     }
 
     public removeIndexSuffix(filePath: string): string {
-        if (!this.conf('removeIndexSuffix', false)) {
+        if (!this.conf('removeIndexSuffix', true)) {
             return filePath;
         }
         const indexSuffix = '/index';

--- a/src/index/referenceindexer.ts
+++ b/src/index/referenceindexer.ts
@@ -415,6 +415,17 @@ export class ReferenceIndexer {
         return filePath;
     }
 
+    public removeIndexSuffix(filePath: string): string {
+        if (!this.conf('removeIndexSuffix', false)) {
+            return filePath;
+        }
+        const indexSuffix = '/index';
+        if (filePath.endsWith(indexSuffix)) {
+            return filePath.slice(0, -indexSuffix.length);
+        }
+        return filePath;
+    }
+
     public updateImports(from: string, to: string): Promise<any> {
         const affectedFiles = this.index.getReferences(from);
         const promises = affectedFiles.map(filePath => {
@@ -424,6 +435,7 @@ export class ReferenceIndexer {
 
                 let newRelative = this.getRelativePath(filePath.path, to);
                 newRelative = this.removeExtension(newRelative);
+                newRelative = this.removeIndexSuffix(newRelative);
 
                 return [[relative, newRelative]];
             });


### PR DESCRIPTION
Resolves #28

Adds ability to remove `index` from file imports once moved.

Eg `import blah from '../folder/index'` to `import blah from '../folder'`

Also updates the node deps as theyre oldddd and have vulnerabilities. Now works with node 12